### PR TITLE
Fix serializer for non html strings

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,3 +1,13 @@
+exports[`jest-serializer-html-string should not reformat something that is not an html string 1`] = `2`;
+
+exports[`jest-serializer-html-string should not reformat something that is not an html string 2`] = `true`;
+
+exports[`jest-serializer-html-string should not reformat something that is not an html string 3`] = `Array []`;
+
+exports[`jest-serializer-html-string should not reformat something that is not an html string 4`] = `Object {}`;
+
+exports[`jest-serializer-html-string should not reformat something that is not an html string 5`] = `"Non html tags strings"`;
+
 exports[`jest-serializer-html-string should reformat a given html 1`] = `
 <body>
   <div class="home active">

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -14,5 +14,12 @@ describe('jest-serializer-html-string', () => {
 	it('should reformat a given html', () => {
 		expect(unfmtHtml).toMatchSnapshot();
 	});
-});
 
+	it('should not reformat something that is not an html string', () => {
+		expect(2).toMatchSnapshot();
+		expect(true).toMatchSnapshot();
+		expect([]).toMatchSnapshot();
+		expect({}).toMatchSnapshot();
+		expect('Non html tags strings').toMatchSnapshot();
+	});
+});

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use string';
 
 var html = require('html');
+var isHtml = require('is-html');
 
 module.exports = {
 	test: function (val) {
-		return val;
+		return isHtml(val);
 	},
 	print: function (val) {
 		return html.prettyPrint(val, {
@@ -13,4 +14,3 @@ module.exports = {
 		});
 	}
 };
-

--- a/package.json
+++ b/package.json
@@ -38,10 +38,13 @@
     "jest": "^18.1.0"
   },
   "dependencies": {
-    "html": "^1.0.0"
+    "html": "^1.0.0",
+    "is-html": "^1.1.0"
   },
   "jest": {
     "testEnvironment": "node",
-    "snapshotSerializers": ["./index.js"]
+    "snapshotSerializers": [
+      "./index.js"
+    ]
   }
 }


### PR DESCRIPTION
The current serializer matches everything, but this was causing issues when something was not an html string. This error was received:
```
TypeError: this.input.charAt is not a function
```

Limiting the serializer to html strings resolve the issue.