### PR TITLE
Fix non-standard objects

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -6,7 +6,9 @@ exports[`jest-serializer-html-string should not reformat something that is not a
 
 exports[`jest-serializer-html-string should not reformat something that is not an html string 4`] = `Object {}`;
 
-exports[`jest-serializer-html-string should not reformat something that is not an html string 5`] = `"Non html tags strings"`;
+exports[`jest-serializer-html-string should not reformat something that is not an html string 5`] = `Object {}`;
+
+exports[`jest-serializer-html-string should not reformat something that is not an html string 6`] = `"Non html tags strings"`;
 
 exports[`jest-serializer-html-string should reformat a given html 1`] = `
 <body>

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -20,6 +20,7 @@ describe('jest-serializer-html-string', () => {
 		expect(true).toMatchSnapshot();
 		expect([]).toMatchSnapshot();
 		expect({}).toMatchSnapshot();
+		expect(Object.create(null)).toMatchSnapshot();
 		expect('Non html tags strings').toMatchSnapshot();
 	});
 });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var isHtml = require('is-html');
 
 module.exports = {
 	test: function (val) {
-		return isHtml(val);
+		return typeof val === 'string' && isHtml(val);
 	},
 	print: function (val) {
 		return html.prettyPrint(val, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-serializer-html-string",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A better Jest snapshot serializer for plain html strings",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
`jest-serializer-html-string` causes issues when you have an object somewhere in your codebase which doesn't have a `toString` method. This happens when the Object doesn't extend from the Object prototype. This PR includes the test and the solution.